### PR TITLE
Add backup restoration dialog

### DIFF
--- a/src/app/sections/backup/backup-controller.js
+++ b/src/app/sections/backup/backup-controller.js
@@ -62,8 +62,20 @@ angular.module('koastAdminApp.sections.backup.backup-controller', [
         });
     };
 
+    vm.confirmingRestore = false;
+    vm.confirmRestore = function(backupToRestore) {
+      vm.confirmingRestore = true;
+      vm.toRestore = backupToRestore;
+    };
+
+    vm.cancelRestore = function() {
+      vm.confirmingRestore = false;
+      vm.toRestore = {};
+    };
+
     var restoringInterval;
     vm.restoreBackup = function (id) {
+      vm.confirmingRestore = false;
       vm.restoringBackup = true;
       vm.restoringPercent = 0;
       vm.restoringName = id;

--- a/src/app/sections/backup/backup-controller.test.js
+++ b/src/app/sections/backup/backup-controller.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+describe('backupCtrl:', function () {
+	var backupCtrl,
+		tagList = {},
+		backupRecord = {
+			backupId: '34072750-9b3a-11e4-adf0-8b69b77a50cb',
+			receipts: [
+				{
+					collection: 'tasks',
+					data: {
+						bucket: 'mock-bucket',
+						key: 'mock'
+					}
+				},
+				{
+					collection: 'users',
+					data: {
+						bucket: 'mock-bucket',
+						key: 'mock'
+					}
+				}
+			]
+		};
+
+	beforeEach(module('koastAdminApp.sections.backup.backup-controller'));
+
+  beforeEach(inject(function ($controller, $interval, $q) {
+		var mockBackup = {
+			list: function () {
+				return $q.when([backupRecord]);
+			},
+			restoreBackup: function (id) {
+				var deferred = $q.defer();
+				deferred.resolve('done');  // this is what seems to happen currently.
+				return deferred.promise;
+			}
+		};
+
+    backupCtrl = $controller('backupCtrl', {
+      $interal: $interval,
+      backup: mockBackup,
+      tagList: tagList
+    });
+  }));
+
+	it('should show a dialog when restore is clicked', function () {
+		expect(backupCtrl.confirmingRestore).to.be.false();
+		expect(backupCtrl.restoringBackup).to.be.not.ok();
+
+		backupCtrl.confirmRestore(backupRecord);
+
+		expect(backupCtrl.confirmingRestore).to.be.true();
+		expect(backupCtrl.restoringBackup).to.be.not.ok();
+		expect(backupCtrl.toRestore).to.be.equal(backupRecord);
+	});
+
+	describe('verify correct effects happen from backup restore confirmation dialog', function () {
+		beforeEach(function () {
+			backupCtrl.toRestore = backupRecord;
+			backupCtrl.confirmingRestore = true;			
+		});
+
+		it('should start restoring when OK is clicked in the confirmation dialog', function () {
+			expect(backupCtrl.restoringBackup).to.be.not.ok();
+
+			backupCtrl.restoreBackup(backupRecord.backupId);
+
+			expect(backupCtrl.confirmingRestore).to.be.false();
+			expect(backupCtrl.restoringBackup).to.be.true();
+			expect(backupCtrl.toRestore).to.be.equal(backupRecord);
+		});
+
+		it('should not start restoring when Cancel is clicked in the confirmation dialog', function () {
+			expect(backupCtrl.restoringBackup).to.be.not.ok();
+
+			backupCtrl.cancelRestore();
+
+			expect(backupCtrl.confirmingRestore).to.be.false();
+			expect(backupCtrl.restoringBackup).to.be.not.ok();
+			expect(backupCtrl.toRestore).to.be.empty();
+		});
+	});
+});

--- a/src/app/sections/backup/backup-controller.test.js
+++ b/src/app/sections/backup/backup-controller.test.js
@@ -1,41 +1,41 @@
 'use strict';
 
 describe('backupCtrl:', function () {
-	var backupCtrl,
-		tagList = {},
-		backupRecord = {
-			backupId: '34072750-9b3a-11e4-adf0-8b69b77a50cb',
-			receipts: [
-				{
-					collection: 'tasks',
-					data: {
-						bucket: 'mock-bucket',
-						key: 'mock'
-					}
-				},
-				{
-					collection: 'users',
-					data: {
-						bucket: 'mock-bucket',
-						key: 'mock'
-					}
-				}
-			]
-		};
+  var backupCtrl,
+    tagList = {},
+    backupRecord = {
+      backupId: '34072750-9b3a-11e4-adf0-8b69b77a50cb',
+      receipts: [
+        {
+          collection: 'tasks',
+          data: {
+            bucket: 'mock-bucket',
+            key: 'mock'
+          }
+        },
+        {
+          collection: 'users',
+          data: {
+            bucket: 'mock-bucket',
+            key: 'mock'
+          }
+        }
+      ]
+    };
 
-	beforeEach(module('koastAdminApp.sections.backup.backup-controller'));
+  beforeEach(module('koastAdminApp.sections.backup.backup-controller'));
 
   beforeEach(inject(function ($controller, $interval, $q) {
-		var mockBackup = {
-			list: function () {
-				return $q.when([backupRecord]);
-			},
-			restoreBackup: function (id) {
-				var deferred = $q.defer();
-				deferred.resolve('done');  // this is what seems to happen currently.
-				return deferred.promise;
-			}
-		};
+    var mockBackup = {
+      list: function () {
+        return $q.when([backupRecord]);
+      },
+      restoreBackup: function (id) {
+        var deferred = $q.defer();
+        deferred.resolve('done');  // this is what seems to happen currently.
+        return deferred.promise;
+      }
+    };
 
     backupCtrl = $controller('backupCtrl', {
       $interal: $interval,
@@ -44,41 +44,41 @@ describe('backupCtrl:', function () {
     });
   }));
 
-	it('should show a dialog when restore is clicked', function () {
-		expect(backupCtrl.confirmingRestore).to.be.false();
-		expect(backupCtrl.restoringBackup).to.be.not.ok();
+  it('should show a dialog when restore is clicked', function () {
+    expect(backupCtrl.confirmingRestore).to.be.false();
+    expect(backupCtrl.restoringBackup).to.be.not.ok();
 
-		backupCtrl.confirmRestore(backupRecord);
+    backupCtrl.confirmRestore(backupRecord);
 
-		expect(backupCtrl.confirmingRestore).to.be.true();
-		expect(backupCtrl.restoringBackup).to.be.not.ok();
-		expect(backupCtrl.toRestore).to.be.equal(backupRecord);
-	});
+    expect(backupCtrl.confirmingRestore).to.be.true();
+    expect(backupCtrl.restoringBackup).to.be.not.ok();
+    expect(backupCtrl.toRestore).to.be.equal(backupRecord);
+  });
 
-	describe('verify correct effects happen from backup restore confirmation dialog', function () {
-		beforeEach(function () {
-			backupCtrl.toRestore = backupRecord;
-			backupCtrl.confirmingRestore = true;			
-		});
+  describe('verify correct effects happen from backup restore confirmation dialog', function () {
+    beforeEach(function () {
+      backupCtrl.toRestore = backupRecord;
+      backupCtrl.confirmingRestore = true;      
+    });
 
-		it('should start restoring when OK is clicked in the confirmation dialog', function () {
-			expect(backupCtrl.restoringBackup).to.be.not.ok();
+    it('should start restoring when OK is clicked in the confirmation dialog', function () {
+      expect(backupCtrl.restoringBackup).to.be.not.ok();
 
-			backupCtrl.restoreBackup(backupRecord.backupId);
+      backupCtrl.restoreBackup(backupRecord.backupId);
 
-			expect(backupCtrl.confirmingRestore).to.be.false();
-			expect(backupCtrl.restoringBackup).to.be.true();
-			expect(backupCtrl.toRestore).to.be.equal(backupRecord);
-		});
+      expect(backupCtrl.confirmingRestore).to.be.false();
+      expect(backupCtrl.restoringBackup).to.be.true();
+      expect(backupCtrl.toRestore).to.be.equal(backupRecord);
+    });
 
-		it('should not start restoring when Cancel is clicked in the confirmation dialog', function () {
-			expect(backupCtrl.restoringBackup).to.be.not.ok();
+    it('should not start restoring when Cancel is clicked in the confirmation dialog', function () {
+      expect(backupCtrl.restoringBackup).to.be.not.ok();
 
-			backupCtrl.cancelRestore();
+      backupCtrl.cancelRestore();
 
-			expect(backupCtrl.confirmingRestore).to.be.false();
-			expect(backupCtrl.restoringBackup).to.be.not.ok();
-			expect(backupCtrl.toRestore).to.be.empty();
-		});
-	});
+      expect(backupCtrl.confirmingRestore).to.be.false();
+      expect(backupCtrl.restoringBackup).to.be.not.ok();
+      expect(backupCtrl.toRestore).to.be.empty();
+    });
+  });
 });

--- a/src/app/sections/backup/backup.html
+++ b/src/app/sections/backup/backup.html
@@ -22,8 +22,8 @@
       <td>{{backup.name}}</td>
       <td>{{backup.timestamp | date:'yyyy-MM-dd'}}</td>
       <td><button class="btn btn--outline pull-right"
-                  ng-click="backupCtrl.restoreBackup(backup.id)"
-                  ng-disabled="backupCtrl.restoringBackup">restore</button>
+            ng-click="backupCtrl.confirmRestore(backup)"
+            ng-disabled="backupCtrl.restoringBackup">Restore</button>
       </td>
     </tr>
   </tbody>
@@ -35,6 +35,39 @@
     <i class="fa fa-database fa-5x"></i>
     <!-- Main Title -->
     <h3 class="empty-state__title">No backups found</h3>
+  </div>
+</div>
+
+<div ng-class="{ false: 'modal', true: 'modal--show' }[backupCtrl.confirmingRestore]">
+  <!-- Overlay -->
+  <div class="overlay" ng-click="backupCtrl.cancelRestore()"></div>
+  <!-- Modal Content -->
+  <div class="modal__contents modal--transition">
+    <!-- Close button -->
+    <h3 class="modal__header">
+      <a class="modal__close" href="" ng-click="backupCtrl.cancelRestore()">&times;</a>
+      Confirm Restore
+    </h3>
+    <div class="backup">
+      <h4>Backup : {{ backupCtrl.toRestore.name }}</h4>
+      <h4>Created On : {{ backupCtrl.toRestore.timestamp  | date:'yyyy-MM-dd'}}</h4>
+
+      <h4>Collections</h4>
+      <ul>
+        <li ng-repeat="receipt in backupCtrl.toRestore.receipts">{{ receipt.collection }}</li>
+        <li ng-show="backupCtrl.toRestore.receipts.length === 0">None selected</li>
+      </ul>
+    </div>
+    <div class="modal__footer">
+      <button class="btn btn--outline"
+              ng-click="backupCtrl.cancelRestore()"
+              ng-disabled="backupCtrl.restoringBackup">Cancel</button>
+
+      <button class="btn btn--success"
+              ng-click="backupCtrl.restoreBackup(backupCtrl.toRestore.backupId)"
+              ng-disabled="backupCtrl.restoringBackup">OK</button>
+    </div>
+
   </div>
 </div>
 


### PR DESCRIPTION
Now, when you click restore alongside one of the backup records, instead of the restore being triggered, a modal dialog will display that shows details about the restore, along with OK/Cancel buttons (Whose order should perhaps be switched).