### PR TITLE
[#86037994] Adds a directive for focusing on a named form element.

### DIFF
--- a/src/app/components/components.js
+++ b/src/app/components/components.js
@@ -1,5 +1,6 @@
 angular.module('koastAdminApp.components', [
     'koastAdminApp.components.navbar',
     'koastAdminApp.components.taglist',
-    'koastAdminApp.components.rgEscKeyup'
+    'koastAdminApp.components.rgEscKeyup',
+    'koastAdminApp.components.formFocus'
 ]);

--- a/src/app/components/formFocus/formFocus-directive.js
+++ b/src/app/components/formFocus/formFocus-directive.js
@@ -1,0 +1,13 @@
+'use strict';
+angular.module('koastAdminApp.components.formFocus.formFocus-directive', []).directive('formFocus', [function () {
+  return {
+    restrict: 'A',
+    link: function (scope, element, attrs) {
+      element.on('click', function () {
+        var formField = document.getElementsByName(attrs.formFocus)[0];
+        // Shenanigans. Weird timing issue was preventing focus() from being called, so wait.
+        setTimeout(function () {formField.focus()}, 100);
+      });
+    }
+  };
+}]);

--- a/src/app/components/formFocus/formFocus.js
+++ b/src/app/components/formFocus/formFocus.js
@@ -1,0 +1,1 @@
+angular.module('koastAdminApp.components.formFocus', ['koastAdminApp.components.formFocus.formFocus-directive']);

--- a/src/app/sections/backup/backup.html
+++ b/src/app/sections/backup/backup.html
@@ -10,6 +10,7 @@
 <p class="add-bottom text-right">
   <button ng-disabled="backupCtrl.restoringBackup" ng-click="backupCtrl.show()"
           rg-esc-keyup="backupCtrl.hide()"
+          form-focus="backupName"
           class="btn btn--success">
             <i class="fa fa-plus"></i>
             Create New Backup


### PR DESCRIPTION
For inexplicable reasons, focusing on any form field in the modal dialog wouldn't work, but
adding a delay seems to encourage this.
Using form-focus="(input name)" on a clickable element will focus on the input with that name
when the element with the directive is clicked.
